### PR TITLE
Add pylint to precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,8 @@ repos:
     hooks:
       - id: black-jupyter
 
-  - repo: local
+  - repo: https://github.com/PyCQA/pylint
+    rev: "v2.16.2"
     hooks:
       - id: pylint
         name: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,19 @@ repos:
     hooks:
       - id: black-jupyter
 
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        args: [
+            "-rn", # Only display messages
+            "-sn", # Don't display the score
+            "--rcfile=pyproject.toml", # Link to your config file
+          ]
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v4.4.0"
     hooks:


### PR DESCRIPTION
Caught on on PR #18 by not having pylint in the pre-commit hook - could we add this in? 

Ripped pretty much straight out of [the pylint docs](https://pylint.readthedocs.io/en/latest/user_guide/installation/pre-commit-integration.html)