### PR TITLE
Warn unexpected length of school report PDF

### DIFF
--- a/src/rred_reports/reports/README.md
+++ b/src/rred_reports/reports/README.md
@@ -33,6 +33,15 @@ virtualenv/conda env there is some first-time setup required:
     is most likely a typo in the date, ask the research team for the correct
     value if not obvious. report with the `pupil_no` and `rred_user_id`,
     correcting to a temporarily likely value to be able to check for more errors
+  - If you get an error during conversion of word docs to pdfs that contains
+    `'result': 'error', 'error': 'Error: Message not understood.'`, then chances
+    are the file in the message is opened in word. Close the file and then rerun
+    `rred reports convert output/reports/{year}/schools`
+  - If you get a warning about a report having an unexpected number of pages,
+    open the Word document and check that a table hasn't been split over
+    multiple lines. If this happens ask the RRED team if we want to decrease the
+    font size for it to fit, or separate into two pages with the header on each
+    page.
   - If you get errors which aren't clear, you can run the reports/interface.py
     file in debug mode in your IDE, altering the `if __name__ == "__main__":` to
     call the `create` function.

--- a/src/rred_reports/reports/generate.py
+++ b/src/rred_reports/reports/generate.py
@@ -9,6 +9,8 @@ from tqdm import tqdm
 
 from rred_reports.reports.schools import populate_school_data, school_filter
 
+_EXPECTED_PAGE_COUNT = 10
+
 
 class ReportConversionException(Exception):
     """Custom exception generator for the TemplateFiller class"""
@@ -68,7 +70,15 @@ def validate_pdf(pdf_file_path: Path) -> bool:
 
     with pdf_file_path.open("rb") as converted_report:
         try:
-            PdfReader(converted_report)
+            reader = PdfReader(converted_report)
+            pages_in_pdf = len(reader.pages)
+            if pages_in_pdf != _EXPECTED_PAGE_COUNT:
+                logger.warning(
+                    "File {pdf_file_path} had {pages_in_pdf} pages, {expected_pages} pages were expected. Check for tables spanning multiple pages",
+                    pdf_file_path=pdf_file_path,
+                    pages_in_pdf=pages_in_pdf,
+                    expected_pages=_EXPECTED_PAGE_COUNT,
+                )
         except EmptyFileError as error:
             message = f"Report conversion failed - empty PDF produced: {pdf_file_path}"
             raise ReportConversionException(message) from error

--- a/tests/test_reports_generate.py
+++ b/tests/test_reports_generate.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from _pytest.logging import LogCaptureFixture
 from pypdf import PdfMerger, PdfReader
 from pypdf.errors import EmptyFileError, PdfReadError
 
@@ -38,6 +39,16 @@ def test_convert_single_report_success(mocker, template_report_path: Path, temp_
     convert_all_reports([template_report_path], [output_file_path])
     pdf_conversion_mock.assert_called_once()
     pdf_validity_check_mock.assert_called_once()
+
+
+def test_validate_pdf_with_unexpected_number_of_pages(template_report_pdf_path: Path, loguru_caplog: LogCaptureFixture):
+    """
+    Given a pdf to validate that has 2 pages
+    When the pdf is validated
+    Then loguru will log that 10 pages were expected
+    """
+    validate_pdf(template_report_pdf_path)
+    assert "10 pages were expected" in loguru_caplog.text
 
 
 def test_validate_pdf_failure_missing_file():


### PR DESCRIPTION
Add warnings that a PDF isn't the expected number of pages, so that we can know when a table seems to be split over multiple pages before a manual check